### PR TITLE
Head request

### DIFF
--- a/acceptance-tests.sh
+++ b/acceptance-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 gem install bundler
-wget https://github.com/wynspeare/http_server_spec/archive/work-in-progress.tar.gz
-tar -xzvf work-in-progress.tar.gz
-cd http_server_spec-work-in-progress && bundle install
-bundle exec spinach
+wget https://github.com/wynspeare/http_server_spec/archive/master.tar.gz
+tar -xzvf master.tar.gz
+cd http_server_spec-master && bundle install
+bundle exec spinach --tags @simple-get,@simple-head

--- a/src/main/java/server/HTTPServer.java
+++ b/src/main/java/server/HTTPServer.java
@@ -1,5 +1,8 @@
 package server;
 
+import server.wrappers.IServerSocketWrapper;
+import server.wrappers.ServerSocketWrapper;
+
 import java.io.IOException;
 
 public class HTTPServer {

--- a/src/main/java/server/ServerRunnable.java
+++ b/src/main/java/server/ServerRunnable.java
@@ -2,6 +2,7 @@ package server;
 
 import server.request.Request;
 import server.request.Handler;
+import server.wrappers.ISocketWrapper;
 
 public class ServerRunnable implements Runnable {
     public ISocketWrapper socketWrapper;
@@ -16,10 +17,10 @@ public class ServerRunnable implements Runnable {
             if (clientMessage != null) {
                 Request request = new Request(clientMessage);
                 Handler handler = new Handler(request);
-                String response = handler.buildResponse();
+                Response response = handler.buildResponse();
                 System.out.println("Message received by server: " + clientMessage);
                 System.out.println("RESPONSE: " + response);
-                socketWrapper.sendData(response);
+                socketWrapper.sendData(response.getStatusLine());
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -28,5 +29,4 @@ public class ServerRunnable implements Runnable {
             socketWrapper.close();
         }
     }
-
 }

--- a/src/main/java/server/request/Handler.java
+++ b/src/main/java/server/request/Handler.java
@@ -19,15 +19,11 @@ public class Handler {
     return request.getRequestMethod().equals(Methods.HEAD.toString());
   }
 
-  public String buildResponse() {
+  public Response buildResponse() {
     Response response = new Response();
-    Methods incomingMethod = Methods.valueOf(request.getRequestMethod());
-    switch(incomingMethod) {
-      case GET:
-      case HEAD:
-        response.build(StatusCode.OK);
-        break;
+    if (isGETRequest() || isHEADRequest()) {
+      response.build(StatusCode.OK);
     }
-    return response.getStatusLine();
+    return response;
   }
 }

--- a/src/main/java/server/request/Handler.java
+++ b/src/main/java/server/request/Handler.java
@@ -12,19 +12,22 @@ public class Handler {
   }
 
   public Boolean isGETRequest() {
-    if (request.getRequestMethod().equals(Methods.GET.toString())) {
-      return true;
-    }
-    return false;
+    return request.getRequestMethod().equals(Methods.GET.toString());
+  }
+
+  public Boolean isHEADRequest() {
+    return request.getRequestMethod().equals(Methods.HEAD.toString());
   }
 
   public String buildResponse() {
-    if (isGETRequest()) {
-      Response response = new Response();
-      response.build(StatusCode.OK);
-      return response.getStatusLine();
+    Response response = new Response();
+    Methods incomingMethod = Methods.valueOf(request.getRequestMethod());
+    switch(incomingMethod) {
+      case GET:
+      case HEAD:
+        response.build(StatusCode.OK);
+        break;
     }
-    return null;
+    return response.getStatusLine();
   }
-
 }

--- a/src/main/java/server/wrappers/IServerSocketWrapper.java
+++ b/src/main/java/server/wrappers/IServerSocketWrapper.java
@@ -1,4 +1,4 @@
-package server;
+package server.wrappers;
 
 import java.io.IOException;
 

--- a/src/main/java/server/wrappers/ISocketWrapper.java
+++ b/src/main/java/server/wrappers/ISocketWrapper.java
@@ -1,4 +1,4 @@
-package server;
+package server.wrappers;
 
 public interface ISocketWrapper {
     String receiveData();

--- a/src/main/java/server/wrappers/ServerSocketWrapper.java
+++ b/src/main/java/server/wrappers/ServerSocketWrapper.java
@@ -1,4 +1,4 @@
-package server;
+package server.wrappers;
 
 import java.io.IOException;
 import java.net.ServerSocket;

--- a/src/main/java/server/wrappers/ServerSocketWrapperSpy.java
+++ b/src/main/java/server/wrappers/ServerSocketWrapperSpy.java
@@ -1,4 +1,4 @@
-package server;
+package server.wrappers;
 
 import java.io.BufferedReader;
 import java.io.PrintWriter;

--- a/src/main/java/server/wrappers/SocketWrapper.java
+++ b/src/main/java/server/wrappers/SocketWrapper.java
@@ -1,4 +1,4 @@
-package server;
+package server.wrappers;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/main/java/server/wrappers/SocketWrapperSpy.java
+++ b/src/main/java/server/wrappers/SocketWrapperSpy.java
@@ -1,4 +1,4 @@
-package server;
+package server.wrappers;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/test/server/HandlerTest.java
+++ b/src/test/server/HandlerTest.java
@@ -23,4 +23,20 @@ public class HandlerTest {
     assertEquals("HTTP/1.1 200 OK\r\n", handler.buildResponse());
   }
 
+  @Test
+  public void handlerChecksIfRequestIsAHEAD() {
+    Request request = new Request("HEAD /simple_get HTTP/1.1");
+    Handler handler = new Handler(request);
+
+    assertTrue(handler.isHEADRequest());
+  }
+
+  @Test
+  public void handlerBuildsTheCorrectResponseStatusLineFromAHeadRequest() {
+    Request request = new Request("HEAD /simple_get HTTP/1.1");
+    Handler handler = new Handler(request);
+
+    assertEquals("HTTP/1.1 200 OK\r\n", handler.buildResponse());
+  }
+
 }

--- a/src/test/server/HandlerTest.java
+++ b/src/test/server/HandlerTest.java
@@ -19,8 +19,9 @@ public class HandlerTest {
   public void handlerBuildsTheCorrectResponseStatusLine() {
     Request request = new Request("GET /simple_get HTTP/1.1");
     Handler handler = new Handler(request);
+    Response response = handler.buildResponse();
 
-    assertEquals("HTTP/1.1 200 OK\r\n", handler.buildResponse());
+    assertEquals("HTTP/1.1 200 OK\r\n", response.getStatusLine());
   }
 
   @Test
@@ -35,8 +36,8 @@ public class HandlerTest {
   public void handlerBuildsTheCorrectResponseStatusLineFromAHeadRequest() {
     Request request = new Request("HEAD /simple_get HTTP/1.1");
     Handler handler = new Handler(request);
+    Response response = handler.buildResponse();
 
-    assertEquals("HTTP/1.1 200 OK\r\n", handler.buildResponse());
+    assertEquals("HTTP/1.1 200 OK\r\n", response.getStatusLine());
   }
-
 }

--- a/src/test/server/ServerRunnableTest.java
+++ b/src/test/server/ServerRunnableTest.java
@@ -1,6 +1,8 @@
 package server;
 
 import org.junit.Test;
+import server.wrappers.SocketWrapperSpy;
+
 import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.io.StringReader;
@@ -61,7 +63,7 @@ public class ServerRunnableTest {
   }
 
   @Test
-  public void twoRunnablesListensAndRespondForSimpleGet() {
+  public void twoRunnablesListenAndRespondForSimpleGet() {
 
     BufferedReader input = new BufferedReader(
             new StringReader("GET /simple_get HTTP/1.1\n"));

--- a/src/test/server/ServerRunnableTest.java
+++ b/src/test/server/ServerRunnableTest.java
@@ -60,4 +60,29 @@ public class ServerRunnableTest {
     assertTrue(socketWrapperSpy.wasCloseCalled());
   }
 
+  @Test
+  public void twoRunnablesListensAndRespondForSimpleGet() {
+
+    BufferedReader input = new BufferedReader(
+            new StringReader("GET /simple_get HTTP/1.1\n"));
+    PrintWriter output = new PrintWriter(new StringWriter(), true);
+    SocketWrapperSpy socketWrapperSpy = new SocketWrapperSpy(input, output);
+
+    ServerRunnable runnable = new ServerRunnable(socketWrapperSpy);
+    runnable.run();
+
+    BufferedReader input2 = new BufferedReader(
+            new StringReader("GET /simple_get HTTP/1.1\n"));
+    SocketWrapperSpy socketWrapperSpy2 = new SocketWrapperSpy(input2, output);
+
+    ServerRunnable secondRunnable = new ServerRunnable(socketWrapperSpy2);
+    secondRunnable.run();
+
+    assertEquals("HTTP/1.1 200 OK\r\n", socketWrapperSpy.getSentData());
+    assertTrue(socketWrapperSpy.wasCloseCalled());
+
+    assertEquals("HTTP/1.1 200 OK\r\n", socketWrapperSpy2.getSentData());
+    assertTrue(socketWrapperSpy2.wasCloseCalled());
+  }
+
 }


### PR DESCRIPTION
GIVEN I make a HEAD request to /simple_get_with_body
WHEN I expect to have a response with a 200 status code
AND the response has an empty body 

- All tests are passing
- `buildResponse` in `Handler` no longer returns a null
- Modified `acceptance-tests.sh` to point to `master` branch of `http_server_spec` repo and run specific tests via `--tags` flag
- Moved wrappers into separate package